### PR TITLE
feat(q1): [C2] レーティング規則（年齢制限）の実装

### DIFF
--- a/src/q1/solve.spec.ts
+++ b/src/q1/solve.spec.ts
@@ -31,7 +31,7 @@ describe('Q1 solve', () => {
   // ------------------------------
   // [C2] レーティング規則（年齢制限）
   // ------------------------------
-  it.skip('[C2] R18+ を Young/Child で購入不可 → 年齢制限', () => {
+  it('[C2] R18+ を Young/Child で購入不可 → 年齢制限', () => {
     const y = solve('Young,R18+,10:00,1:00,A-1');
     const c = solve('Child,R18+,10:00,1:00,I-2');
     expect(y).toBe('対象の映画は年齢制限により閲覧できません');
@@ -43,7 +43,7 @@ describe('Q1 solve', () => {
     expect(out).toBe('対象の映画は年齢制限により閲覧できません');
   });
 
-  it.skip('[C2] PG-12 を Adult + Child 同時購入 → 両方購入可', () => {
+  it('[C2] PG-12 を Adult + Child 同時購入 → 両方購入可', () => {
     const input = [
       'Adult,PG-12,10:00,1:00,A-1',
       'Child,PG-12,10:00,1:00,I-2',

--- a/src/q1/solve.ts
+++ b/src/q1/solve.ts
@@ -148,7 +148,17 @@ const checkRating = (
   rating: Rating,
   hasAdultInSet: boolean
 ): boolean => {
-  // TODO ここを実装
+
+  if( rating === 'G') return true;
+  if( rating === 'PG-12'){
+    if(age === 'Child' && !hasAdultInSet) return false;
+    return true;
+  }
+  if( rating === 'R18+'){
+    if(age !== 'Adult') return false;
+    return true;
+  }
+
   return true;
 };
 


### PR DESCRIPTION
## 概要
- 映画チケットのレーティング規則（年齢制限）を実装しました。

## 内容
- G: 全年齢OK
- PG-12: Child は Adult 同時購入が必要
- R18+: Adult のみ利用可能
- テスト [C2] が通ることを確認済み